### PR TITLE
Add Patient.address.type to dimp_dup_base.yaml

### DIFF
--- a/data-node/fhir-pseudonymizer/dimp_dup_base.yaml
+++ b/data-node/fhir-pseudonymizer/dimp_dup_base.yaml
@@ -37,6 +37,8 @@ fhirPathRules:
     method: keep
   - path: Patient.address.postalCode
     method: keep
+  - path: Patient.address.type
+    method: keep
   ### Keep if patient deceased boolean
   - path: Patient.deceased.ofType(boolean)
     method: keep


### PR DESCRIPTION
This fixes issue [198](https://github.com/medizininformatik-initiative/dataportal/issues/198)

With this change flattening will be able to indentify `Patient.address:Strassenanschrift` slice and thus produce a non-empty column for children like `Patient.address:Strassenanschrift.postalCode`. See issue [198](https://github.com/medizininformatik-initiative/dataportal/issues/198) for more detailed description on the changes. 

This was succesfully tested with the COMPACT project.